### PR TITLE
Replace Travis CI with Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Dub Tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        compiler: [dmd-latest, ldc-latest, dmd-2.085.0, ldc-1.17.0]
+        exclude:
+          - { os: macOS-latest, compiler: dmd-2.085.0 }
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ${{ matrix.compiler }}
+
+      - name: Run tests
+        run: dub test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: d
-
-d:
-  - dmd
-  - dmd-2.068.2
-  - dmd-2.067.1
-  - ldc
-  - gdc


### PR DESCRIPTION
Since action was required anyway because of travis-ci.org decommissioning, I've decided to give Github Actions a try,