### PR TITLE
skip string conversion of unmapped bytes

### DIFF
--- a/source/stringex/unidecode.d
+++ b/source/stringex/unidecode.d
@@ -3,22 +3,20 @@ module stringex.unidecode;
 import stringex.replacements;
 import std.utf;
 import std.array;
-import std.conv;
 
 string unidecode(string input)
 {
 	auto result = appender!string();
 
 	foreach(c; input.byDchar()) {
-		result ~= decoded(c);
+		if (c <= 128) result ~= c;
+		else result ~= decoded(c);
 	}
 
 	return result.data;
 }
 
 private string decoded(dchar c) {
-	if (c <= 128) return c.to!string(); // match https://github.com/rsl/stringex/blob/v2.8.5/lib/stringex/unidecoder.rb#L49
-
 	auto grp = c >> 8;
 	auto grouped_point = c & 255;
 


### PR DESCRIPTION
The `std.con.to!string`turns a 16ms benchmark into a 106ms benchmark, and can be skipped by directly using the appender:

```
Benchmark 1 (47 runs): ./toascii-old bin
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           108ms ± 12.3ms     101ms …  161ms          5 (11%)        0%
  peak_rss           8.60MB ± 77.4KB    8.39MB … 8.77MB          0 ( 0%)        0%
  cpu_cycles          480M  ± 58.9M      451M  …  734M           5 (11%)        0%
  instructions       1.47G  ± 47.6K     1.47G  … 1.47G           0 ( 0%)        0%
  cache_references   4.53M  ± 2.15M     3.85M  … 15.2M           6 (13%)        0%
  cache_misses        406K  ± 16.9K      373K  …  449K           0 ( 0%)        0%
  branch_misses      97.9K  ± 2.38K     93.4K  …  103K           0 ( 0%)        0%
Benchmark 2 (296 runs): ./toascii-new bin
  measurement          mean ± σ            min … max           outliers         delta
  wall_time          16.9ms ±  582us    15.8ms … 20.5ms         19 ( 6%)        ⚡- 84.4% ±  1.3%
  peak_rss           9.93MB ± 51.6KB    9.70MB … 9.96MB         54 (18%)        💩+ 15.5% ±  0.2%
  cpu_cycles         59.7M  ± 1.77M     56.8M  … 68.4M          11 ( 4%)        ⚡- 87.6% ±  1.4%
  instructions        199M  ± 3.11K      199M  …  199M           1 ( 0%)        ⚡- 86.5% ±  0.0%
  cache_references    444K  ± 13.6K      412K  …  572K          25 ( 8%)        ⚡- 90.2% ±  5.4%
  cache_misses       40.6K  ± 2.04K     37.7K  … 52.5K          17 ( 6%)        ⚡- 90.0% ±  0.5%
  branch_misses      54.6K  ±  485      53.7K  … 56.5K          23 ( 8%)        ⚡- 44.2% ±  0.3%
```